### PR TITLE
Add required paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0.0
 author=Linnes Lab
 maintainer=Orlando Hoilett <ohoilett@purdue.edu>
 sentence=Arduino library for the MAX5417/18/19 I2C Digital Potentiometers.
+paragraph=
 category=Device Control
 url=https://github.com/LinnesLab/MAX541X
 architectures=*


### PR DESCRIPTION
When the `paragraph` field is missing from library.properties, the Arduino IDE does not recognize the library:

- **Sketch > Include Library > Add .ZIP** Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request (https://github.com/arduino/Arduino/issues/9065) is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format